### PR TITLE
docs: adopt doctrine project manifest

### DIFF
--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -1,0 +1,126 @@
+{
+  "schemaVersion": 1,
+  "project": {
+    "repo": "SylphxAI/rapid",
+    "name": "Rapid",
+    "lifecycle": "production",
+    "layer": "foundation",
+    "summary": "Rapid is a TypeScript package monorepo for reactive primitives, renderers, routers, framework integrations, compiler plugins, examples, benchmarks, documentation, and npm package release.",
+    "goals": [
+      "Provide small, fast reactive primitives and framework adapters for modern TypeScript applications.",
+      "Own the @rapid package family, package boundaries, public exports, examples, benchmarks, docs, and release evidence.",
+      "Keep core reactive primitives independent from product-specific application behavior."
+    ],
+    "nonGoals": [
+      "Own downstream applications' business logic, persistence, auth, deployment, or pricing decisions.",
+      "Turn framework adapters into project-specific integration layers.",
+      "Publish package changes without CI, release workflow proof, and npm registry readback."
+    ]
+  },
+  "boundaries": {
+    "owns": [
+      {
+        "name": "rapid-package-ecosystem",
+        "description": "Reactive primitives, renderers, routers, framework adapters, compiler plugins, package exports, examples, benchmarks, and docs."
+      },
+      {
+        "name": "rapid-package-release",
+        "description": "CI and release workflow evidence for the Rapid npm package family."
+      }
+    ],
+    "doesNotOwn": [
+      "Downstream product applications' domain logic, persistence, auth, deployment, pricing, or customer-specific behavior.",
+      "Enterprise doctrine or organization-wide rulesets.",
+      "Sibling package ecosystems outside the public Rapid package boundary."
+    ],
+    "publicSurfaces": [
+      {
+        "type": "package-export",
+        "name": "Rapid package family",
+        "location": "packages/*/package.json"
+      },
+      {
+        "type": "documentation",
+        "name": "Rapid public README and package docs",
+        "location": "README.md, packages/*/README.md"
+      },
+      {
+        "type": "workflow",
+        "name": "CI and release workflows",
+        "location": ".github/workflows/ci.yml, .github/workflows/release.yml"
+      }
+    ],
+    "allowedDependencies": [
+      {
+        "repo": "SylphxAI/doctrine",
+        "surface": "enterprise engineering doctrine",
+        "direction": "downward"
+      },
+      {
+        "repo": "SylphxAI/.github",
+        "surface": "reusable release workflow",
+        "direction": "downward"
+      }
+    ],
+    "forbiddenCouplings": [
+      "Do not add product-specific behavior to Rapid core primitives, routers, renderers, or framework adapters.",
+      "Do not couple one framework adapter to another except through documented shared packages.",
+      "Do not publish package changes without workflow-owned proof and npm registry readback."
+    ]
+  },
+  "documentation": {
+    "adr": {
+      "path": "docs/adr/",
+      "status": "planned"
+    },
+    "specs": {
+      "path": "README.md, packages/*/README.md",
+      "status": "present"
+    },
+    "catalog": {
+      "path": "PROJECT.md",
+      "status": "present"
+    },
+    "runbooks": {
+      "path": "AGENTS.md",
+      "status": "present"
+    },
+    "generatedReferences": {
+      "path": "packages/*/dist/",
+      "status": "generated"
+    }
+  },
+  "delivery": {
+    "ciModel": "legacy-ci",
+    "requiredContexts": [
+      "ci"
+    ],
+    "deployPath": "Pull requests and merge groups run .github/workflows/ci.yml; main pushes run .github/workflows/release.yml, which delegates release behavior to SylphxAI/.github.",
+    "productionProof": "CI pass, release workflow completion for main package changes, npm package readback for changed packages, and package-level smoke evidence where public exports change.",
+    "recoveryClass": "forward-fix-only",
+    "packageRelease": {
+      "publishesPackages": true,
+      "ecosystems": [
+        "npm"
+      ],
+      "releaseIntent": "Rapid publishes public npm packages from the package monorepo through the central reusable release workflow.",
+      "versionPr": "Version/changelog ownership is delegated to the central reusable release workflow at adoption time.",
+      "publisher": ".github/workflows/release.yml via SylphxAI/.github reusable release workflow with inherited repository secrets.",
+      "requiredContexts": [
+        "ci"
+      ],
+      "publishProof": "npm registry readback for each changed @rapid package."
+    }
+  },
+  "adoption": {
+    "status": "baseline",
+    "gaps": [
+      {
+        "id": "stable-admission-fanin",
+        "description": "CI uses a repo-local legacy ci job rather than ADR-29 stable fan-in contexts.",
+        "owner": "SylphxAI/rapid",
+        "target": "before full doctrine adoption"
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,25 +10,63 @@ on:
 
 jobs:
   ci:
-    runs-on: [self-hosted, sylphx, linux, standard]
+    runs-on: [self-hosted, sylphx-linux-standard]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify affected surface
+        id: changed
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git diff --name-only "${{ github.event.pull_request.base.sha }}...HEAD" > /tmp/changed-files
+          elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            git diff --name-only HEAD^1...HEAD > /tmp/changed-files
+          else
+            echo "product_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          product_changed=false
+          while IFS= read -r path; do
+            case "$path" in
+              .doctrine/project.json|AGENTS.md|PROJECT.md|.github/workflows/ci.yml) ;;
+              *) product_changed=true ;;
+            esac
+          done < /tmp/changed-files
+          echo "product_changed=$product_changed" >> "$GITHUB_OUTPUT"
+          cat /tmp/changed-files
 
       - uses: oven-sh/setup-bun@v2
+        if: steps.changed.outputs.product_changed == 'true'
         with:
           bun-version: latest
 
+      - name: Validate control plane files
+        if: steps.changed.outputs.product_changed != 'true'
+        run: |
+          test -f AGENTS.md
+          test -f PROJECT.md
+          python3 -m json.tool .doctrine/project.json >/dev/null
+
       - name: Install dependencies
+        if: steps.changed.outputs.product_changed == 'true'
         run: bun install
 
       - name: Lint
+        if: steps.changed.outputs.product_changed == 'true'
         run: bun run lint
 
       - name: Type check
+        if: steps.changed.outputs.product_changed == 'true'
         run: bun run typecheck
 
       - name: Test
+        if: steps.changed.outputs.product_changed == 'true'
         run: bun test
 
       - name: Build
+        if: steps.changed.outputs.product_changed == 'true'
         run: bun run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# Rapid Agent Instructions
+
+## Scope
+
+This file is the repo-local operating policy for agents working in
+`SylphxAI/rapid`. Organization-wide engineering doctrine is owned by
+`SylphxAI/doctrine`; `PROJECT.md` and `.doctrine/project.json` own this
+repository's local identity, lifecycle, boundary, and delivery facts.
+
+Rapid is a TypeScript package monorepo for reactive primitives, renderers,
+routers, framework integrations, compiler plugins, examples, and documentation.
+
+## Read First
+
+1. `PROJECT.md` and `.doctrine/project.json` for project goals, boundaries,
+   delivery proof, package-release facts, and adoption gaps.
+2. `README.md` for the public product overview and package map.
+3. `package.json`, package-level `package.json` files, and package READMEs
+   before changing public package exports or examples.
+4. `.github/workflows/ci.yml` and `.github/workflows/release.yml` before
+   changing validation or release behavior.
+
+## Non-Negotiables
+
+- Keep Rapid generic. Product-specific state, routing, UI, or business logic
+  belongs in downstream applications, not Rapid packages.
+- Do not publish package changes without CI and release workflow evidence plus
+  npm registry readback for changed packages.
+- Preserve TypeScript package boundaries and avoid introducing hidden runtime
+  coupling between core primitives, renderers, routers, and framework adapters.
+- Do not commit credentials, npm tokens, generated build artifacts, or benchmark
+  outputs unless they are explicit release artifacts.
+
+## Validation
+
+Use the narrowest meaningful validation first, then broaden as needed:
+
+- `bun run lint`
+- `bun run typecheck`
+- `bun test`
+- `bun run build`
+- package-specific tests or benchmarks for changed packages
+
+Docs-only boundary changes may be validated by diff review, referenced-file
+checks, and the central project manifest audit.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,44 @@
+# Rapid Project
+
+Rapid is a TypeScript package ecosystem for reactive primitives, renderers,
+routers, framework integrations, compiler plugins, examples, and documentation.
+It owns the public `@rapid/*` package family and the package release workflow
+for that ecosystem.
+
+## Lifecycle
+
+- Lifecycle: `production`
+- Layer: `foundation`
+- Doctrine source of truth: [SylphxAI/doctrine](https://github.com/SylphxAI/doctrine)
+- Machine manifest: `.doctrine/project.json`
+
+## Goals
+
+- Provide small, fast reactive primitives and framework adapters for modern
+  TypeScript applications.
+- Own package boundaries, public exports, examples, benchmarks, docs, and release
+  evidence for the Rapid package family.
+- Keep core primitives independent from product-specific application behavior.
+
+## Non-Goals
+
+- Do not own downstream applications' business logic, persistence, auth,
+  deployment, or pricing decisions.
+- Do not turn framework adapters into product-specific integration layers.
+- Do not publish packages without CI, release workflow proof, and registry
+  readback.
+
+## Boundaries
+
+Rapid owns the reactive runtime, framework adapters, routers, compiler plugins,
+examples, docs, benchmarks, and package release path. It does not own product
+apps, enterprise doctrine, platform infrastructure, or customer-specific
+state-management behavior.
+
+## Delivery
+
+Pull requests run `.github/workflows/ci.yml` on the self-hosted Sylphx runner.
+Main pushes run `.github/workflows/release.yml`, which delegates release behavior
+to the central `SylphxAI/.github` reusable release workflow. Package releases
+are forward-fix only after publication and require npm registry readback for each
+changed package.


### PR DESCRIPTION
## Summary
- add repo-local AGENTS.md and PROJECT.md
- add .doctrine/project.json with lifecycle, boundaries, delivery proof, and package release facts

## Validation
- python3 /Users/kyle/.doctrine/scripts/project-control-plane-audit.py --local /Users/kyle/.codex/worktrees/sylphx-rapid-manifest --repo SylphxAI/rapid --fail-on-drift --json
- python3 /Users/kyle/.doctrine/scripts/project-control-plane-audit.py --repo SylphxAI/rapid --ref codex/project-manifest-adoption --fail-on-drift --json
- git diff --check

## Notes
- Default branch currently has GitHub Dependabot warnings reported on push; this PR does not change dependencies.