### PR TITLE
ci: add Changesets config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
+	"changelog": "@changesets/cli/changelog",
+	"commit": false,
+	"fixed": [],
+	"linked": [],
+	"access": "public",
+	"baseBranch": "main",
+	"updateInternalDependencies": "patch",
+	"ignore": []
+}


### PR DESCRIPTION
Release now runs Changesets (reusable workflow migrated off bump). Without a .changeset/config.json the run errors 'There is no .changeset directory in this project'. Adds the org-standard config.