### PR TITLE
Fix legacy Zen recovery Node setup

### DIFF
--- a/.github/workflows/recover-legacy-zen.yml
+++ b/.github/workflows/recover-legacy-zen.yml
@@ -25,6 +25,11 @@ jobs:
           ref: ${{ inputs.source-ref }}
           fetch-depth: 0
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Configure recovery commit identity
         run: |
           git config user.name "github-actions[bot]"
@@ -69,11 +74,6 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
## Summary
- move setup-node before the legacy package patch script

## Why
The first recovery run failed before publish because the self-hosted runner has no `node` binary before `actions/setup-node`.

## Validation
- `git diff --check`
- Failure evidence: Rapid recovery run `28496198933` exited in `Patch legacy package versions` with `node: command not found`

## Follow-up
Merge and rerun `Recover legacy Zen packages`.