### PR TITLE
chore: pin Bun runtime to match packageManager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: steps.changed.outputs.product_changed == 'true'
         with:
-          bun-version: latest
+          bun-version: 1.3.1
 
       - name: Validate control plane files
         if: steps.changed.outputs.product_changed != 'true'
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.changed.outputs.product_changed == 'true'
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Lint
         if: steps.changed.outputs.product_changed == 'true'


### PR DESCRIPTION
## Summary
- pin CI Bun runtime from `latest` to match this repo `packageManager: bun@1.3.1`
- switch Bun install to `--frozen-lockfile` for deterministic CI installs

## Validation
- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run typecheck`
- `bun test`
- `bun run build`